### PR TITLE
Fix typo with docker command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,13 @@ First of all, you may need to enable file sharing for the `shared` folder on you
 
 Then you can start the mocks and other needed infrastructure with the following command.
 ```
-docker-compose up -d simulado influxdb grafana
+docker compose up -d simulado influxdb grafana
 ```
 Check that mocks are working with a sample request to [http://localhost:3001/product/1/similarids](http://localhost:3001/product/1/similarids).
 
 To execute the test run:
 ```
-docker-compose run --rm k6 run scripts/test.js
+docker compose run --rm k6 run scripts/test.js
 ```
 Browse [http://localhost:3000/d/Le2Ku9NMk/k6-performance-test](http://localhost:3000/d/Le2Ku9NMk/k6-performance-test) to view the results.
 


### PR DESCRIPTION
I was unable to run the command
```
$ docker-compose up -d simulado influxdb grafana
# zsh: command not found: docker-compose
```
but I was able to run it with
```
$ docker compose up -d simulado influxdb grafana
```

Feel free to reject this PR if I am missing something here.