### PR TITLE
[FTR] Add new service gateway

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,8 @@ services:
     volumes:
       - ./shared/simulado:/app
     command: ./bin/simulado -f /app/mocks.json
+    networks:
+      - gateway    
   k6:
     image: loadimpact/k6:0.28.0
     ports:
@@ -33,3 +35,15 @@ services:
       - K6_OUT=influxdb=http://influxdb:8086/k6
     extra_hosts:
       - "host.docker.internal:host-gateway"
+  host-gateway:
+    image: andresnator/between:1.0.0
+    depends_on:
+      - simulado
+    ports:
+      - "5000:8080"
+    environment:
+      - JDK_MAX_MEMORY=512m
+    networks:
+      - gateway
+networks:
+  gateway:


### PR DESCRIPTION
## Descripción del PR
Se agrega el servicio `host-gateway` Referente a la prueba técnica del repo https://github.com/andresnator/between/tree/feature/add-host-gateway


## Pasos para reproducir la prueba 

1.  Ejecutar  `docker-compose up -d simulado influxdb grafana host-gateway ` 
2. Ejecutar `docker-compose run --rm k6 run scripts/test.js`

## Evidencia de las pruebas
![S3ILiij6cC](https://user-images.githubusercontent.com/9675877/181028499-997f6de3-682c-48b9-9579-e9f570126486.gif)



## PR Relacionados
https://github.com/andresnator/between/pull/1